### PR TITLE
Return `Poll::Ready(None)` when upstream is closed

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum DecodeError {
+    #[error("incomplete utf8 sequence `{0:?}`")]
+    IncompleteUtf8Sequence(Vec<u8>),
+
     #[error(transparent)]
     Utf8Error(#[from] std::str::Utf8Error),
 


### PR DESCRIPTION
Close #3